### PR TITLE
🔀Components don't have to have a name

### DIFF
--- a/src/components.spec.ts
+++ b/src/components.spec.ts
@@ -35,9 +35,10 @@ describe('integration', () => {
     const max = store.dispatch(actions.createVariable('scope.max', 9));
     const otherMax = store.dispatch(actions.createVariable('scope.max2', 8));
     const range = store.dispatch(actions.createComponent(
-      'range', 'scope.myRange',
+      'range',
       { value: { func: 'x' }, min: { value: 1 }, max },
       { change: { func: '{x: value}' } },
+      { scope: 'scope' },
     ));
 
     expect(range.component?.properties.value.func).toBe('x');
@@ -98,12 +99,13 @@ describe('integration', () => {
   it('should work with transforms', () => {
     const x = store.dispatch(actions.createVariable('test2.x', 3));
     const range = store.dispatch(actions.createComponent(
-      'range', 'test2.myRange',
+      'range',
       {
         value: { func: 'x' },
         transform: { func: 'value == 0 ? "free" : value' },
       },
       { change: { func: '{x: value}' } },
+      { scope: 'test2' },
     ));
     expect(range.state?.transform).toBe(x.get());
     x.set(0);

--- a/src/store/components/actions.ts
+++ b/src/store/components/actions.ts
@@ -1,4 +1,5 @@
 import { v4 as uuid } from 'uuid';
+import { DEFAULT_SCOPE } from '../../constants';
 import { forEachObject } from '../utils';
 import {
   ComponentActionTypes,
@@ -16,7 +17,6 @@ import { Spec } from '../specs/types';
 import { AppThunk, State, Dispatch } from '../types';
 import { getComponent, getComponentState } from './selectors';
 import { getSpec } from '../specs/selectors';
-import { getScopeAndName } from '../variables/utils';
 import { VariableTypes } from '../variables/types';
 import { ComponentShortcut, VariableShortcut } from '../shortcuts';
 
@@ -62,6 +62,8 @@ function componentShortcut<T extends Record<string, VariableTypes>>(
 }
 
 const createComponentOptionDefaults = {
+  scope: DEFAULT_SCOPE,
+  name: null,
   description: '',
 };
 
@@ -110,19 +112,17 @@ function processPropertiesAndEvents<T extends Record<string, VariableTypes>>(
 
 export function createComponent<T extends Record<string, VariableTypes>>(
   specName: string,
-  componentNameAndScope: string,
   properties: {
     [P in keyof T]: PartialProps<T[P]> | VariableShortcut<T[P]>
   },
   events?: Record<string, Omit<ComponentEvent, 'name'>>,
-  options?: CreateComponentOptionDefaults,
+  options?: Partial<CreateComponentOptionDefaults>,
 ): AppThunk<ComponentShortcut<T>> {
   return (dispatch, getState) => {
     const spec = getSpec(getState(), specName);
     if (spec == null) throw new Error('Component spec is not defined.');
     const id = uuid();
-    const { scope, name } = getScopeAndName(componentNameAndScope);
-    const { description } = {
+    const { scope, name, description } = {
       ...createComponentOptionDefaults,
       ...options,
     };

--- a/src/store/components/reducers.spec.ts
+++ b/src/store/components/reducers.spec.ts
@@ -32,19 +32,20 @@ store.dispatch(specActions.createSpec(
 
 describe('Components reducer', () => {
   it('should create component', () => {
-    const badName = actions.createComponent('notRange', '', {}, {});
-    expect(() => store.dispatch(badName as any)).toThrow();
-    const notRange = actions.createComponent('notRange', 'a', {}, {});
+    const notRange = actions.createComponent('notRange', {}, {});
     expect(() => store.dispatch(notRange as any)).toThrow();
-    const badRange = actions.createComponent('range', 'a', { blah: { value: 2 } }, {});
+    const badRange = actions.createComponent('range', { blah: { value: 2 } }, {});
     expect(() => store.dispatch(badRange as any)).toThrow();
     // The null max should likely throw?
     // TODO: The scope should be set rather than the var name.
-    const range = store.dispatch(actions.createComponent('range', 'hi', { min: { value: 2 }, max: { value: null } }, {}) as any) as ComponentShortcut<Record<keyof typeof rangeProps, number>>;
+    const range = store.dispatch(actions.createComponent('range', { min: { value: 2 }, max: { value: null } }) as any) as ComponentShortcut<Record<keyof typeof rangeProps, number>>;
 
     expect(range.scope).toBe(DEFAULT_SCOPE);
-    expect(range.name).toBe('hi');
+    expect(range.name).toBeNull();
     expect(range.state?.min).toBe(2);
     expect(range.state?.max).toBe(100);
+
+    range.set({}, {}, { name: 'hi' });
+    expect(range.name).toBe('hi');
   });
 });

--- a/src/store/components/reducers.ts
+++ b/src/store/components/reducers.ts
@@ -36,7 +36,7 @@ const componentsReducer = (
     case DEFINE_COMPONENT: {
       const { component: newComponent, spec } = action.payload;
       const { scope, name } = newComponent;
-      if (!testScopeAndName(scope, name)) throw new Error('Scope or name has bad characters');
+      if (!testScopeAndName(scope, name, true)) throw new Error('Scope or name has bad characters');
       const component = {
         ...newComponent,
         properties: includeCurrentValueInProps(newComponent.properties, spec),

--- a/src/store/components/types.ts
+++ b/src/store/components/types.ts
@@ -25,7 +25,7 @@ export interface Component {
   spec: string;
   id: string;
   scope: string;
-  name: string;
+  name: string | null;
   description: string;
   properties: Record<string, ComponentProperty>;
   events: Record<string, ComponentEvent>;
@@ -65,11 +65,13 @@ export type ComponentActionTypes = (
 );
 
 export interface CreateComponentOptionDefaults{
+  scope: string;
+  name: string | null;
   description: string;
 }
 export interface UpdateComponentOptionDefaults extends CreateComponentOptionDefaults {
   scope: string;
-  name: string;
+  name: string | null;
 }
 
 export type PartialProps<K = VariableTypes> = Partial<Omit<DefineComponentProperty<K>, 'name'>>;

--- a/src/store/shortcuts.ts
+++ b/src/store/shortcuts.ts
@@ -6,7 +6,7 @@ import { VariableTypes, UpdateVariableOptions, Variable } from './variables/type
 export interface Shortcut<T> {
   readonly id: string;
   readonly scope: string | undefined;
-  readonly name: string | undefined;
+  readonly name: string | null | undefined;
   readonly state: T;
   readonly component: Component | undefined;
   remove: () => void;

--- a/src/store/variables/utils.ts
+++ b/src/store/variables/utils.ts
@@ -50,8 +50,9 @@ export function getScopeAndName(
   return { scope: split[0], name: split[1] };
 }
 
-export function testScopeAndName(scope: string, name: string): boolean {
+export function testScopeAndName(scope: string, name: string | null, allowNull = false): boolean {
   // Simple variable names only ....
   const regex = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
-  return regex.test(scope) && regex.test(name);
+  const testName = allowNull ? name == null || regex.test(name) : name != null && regex.test(name);
+  return regex.test(scope) && testName;
 }


### PR DESCRIPTION
- Change creation of components function
- Allow a null name for components
See also: #4